### PR TITLE
Fixes #18 - vpnc-script-win.js not work in Windows XP.

### DIFF
--- a/nsis/vpnc-script-win.js
+++ b/nsis/vpnc-script-win.js
@@ -34,7 +34,9 @@ function exec(cmd)
        if (fs.FileExists(tmpdir + "vpnc.out")) {
                var f = fs.OpenTextFile(tmpdir + "vpnc.out", 1);
                if (f) {
-                       s = f.ReadAll();
+                      if (!f.AtEndOfStream) {
+                           s = f.ReadAll();
+                       }
                        log.Write(s);
                        f.Close();
 	       }
@@ -66,7 +68,7 @@ function waitForInterface() {
 // Script starts here
 // --------------------------------------------------------------
 
-var internal_ip4_netmask = "255.255.255.0"
+var internal_ip4_netmask = "255.255.255.0";
 
 var ws = WScript.CreateObject("WScript.Shell");
 var env = ws.Environment("Process");
@@ -191,7 +193,7 @@ case "connect":
 	        echo("Configuring Legacy IP networks:");
 	        if (env("INTERNAL_IP6_NETMASK") && !env("INTERNAL_IP6_NETMASK").match("/128$")) {
 			exec("netsh interface ipv6 add route " + env("INTERNAL_IP6_NETMASK") +
-			    " \"" + env("TUNDEV") + "\" fe80::8 store=active")
+			    " \"" + env("TUNDEV") + "\" fe80::8 store=active");
 		}
 
 	        if (env("CISCO_IPV6_SPLIT_INC")) {
@@ -200,7 +202,7 @@ case "connect":
 				var netmasklen = env("CISCO_SPLIT_INC_" + i +
 						 "_MASKLEN");
 				exec("netsh interface ipv6 add route " + network + "/" +
-				    netmasklen + " \"" + env("TUNDEV") + "\" fe80::8 store=active")
+				    netmasklen + " \"" + env("TUNDEV") + "\" fe80::8 store=active");
 			}
 		} else {
 			echo("Setting default IPv6 route through VPN.");


### PR DESCRIPTION
The "route add" command produces an empty output, the file "vpnc.out" is empty (0 bytes) and the script crash (see [here](http://stackoverflow.com/questions/1587591/getting-error-on-while-reading-a-blank-text-file)). With this patch, the script run fine in Windows XP SP2.

Note: In Windows XP the command "netsh interface ipv4 set subinterface ... mtu" does not exist (see [here](http://superuser.com/questions/37686/how-to-tell-what-mtu-is-being-used-in-windows-xp)). For me, works this: only once, I setup the MTU in Control Panel --> Network --> OpenConnect Adapter --> Advanced tab --> MaxFrameSize --> 1406.
