### PR TITLE
Don't quit the app on log-windows close if main window minimized (fix #63)

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -74,6 +74,7 @@ int main(int argc, char *argv[])
 {
     int ret;
     QApplication a(argc, argv);
+    a.setQuitOnLastWindowClosed(false);
     QVariant v;
     MainWindow w;
     QCoreApplication::setOrganizationDomain("redhat.com");


### PR DESCRIPTION
Qt main UI class has a property (default true) to quit the app if last
main visible window is closed.
Anyway we close the app manually because of systray support.