### PR TITLE
Fix: international chars in tap adapter name.

### DIFF
--- a/nsis/vpnc-script.js
+++ b/nsis/vpnc-script.js
@@ -30,7 +30,7 @@ function echo(msg) {
 
 function exec(cmd) {
 	log.WriteLine("<<-- [EXEC] " + cmd);
-	var oExec = ws.Exec(comspec + " /c \"" + cmd + "\" 2>&1");
+	var oExec = ws.Exec(comspec + " /c \"mode con cp select=1250 > nul && " + cmd + "\" 2>&1");
 	var ret = oExec.Status;
     
 	var s = oExec.StdOut.ReadAll();


### PR DESCRIPTION
This pull request fix a bug when the name of the TAP adapter contains internationals characters. For example in Windows 7 in spanish, the TAP interface by default is called "Conexión de área local 2". The original vpnc-script.js script detect this name as "Conexi¢n de  rea local 2" and can't find this adapter. The attached file contains the log before and after the patch.

The symptom is the tunnel is up without error, but the TAP interface does not acquires the IP address and can't send traffic through the tunnel.

Windows 7 Spanish - Openconnect GUI v1.5.1.

[openconnect.txt](https://github.com/openconnect/openconnect-gui/files/1082682/openconnect.txt)
