### PR TITLE
fix bug with second use of saved password

### DIFF
--- a/src/vpninfo.cpp
+++ b/src/vpninfo.cpp
@@ -181,6 +181,7 @@ static int process_auth_form(void* privdata, struct oc_auth_form* form)
                 && strcasecmp(opt->name, "username") == 0) {
                 openconnect_set_option_value(opt,
                     vpn->ss->get_username().toLatin1().data());
+                empty = 0;
                 continue;
             }
 


### PR DESCRIPTION
Missing `empty = 0` assignment upon use of saved password lead to `return OC_FORM_RESULT_CANCELLED` in line 242 and therefore repeated password prompts. use of static `last_form_empty` might lead to similar problems in other cases. One quick fix might be reset it it to 0 on connect button pressed.
Fixes #144.

kind regards,
Jan
