### PR TITLE
Fix verb tense in connection message

### DIFF
--- a/src/dialog/mainwindow.cpp
+++ b/src/dialog/mainwindow.cpp
@@ -460,7 +460,7 @@ void MainWindow::changeStatus(int val)
         if (this->minimize_on_connect) {
             if (m_trayIcon) {
                 hide();
-                m_trayIcon->showMessage(QLatin1String("Connected"), QLatin1String("You were connected to ") + ui->serverList->currentText(),
+                m_trayIcon->showMessage(QLatin1String("Connected"), QLatin1String("You are connected to ") + ui->serverList->currentText(),
                     QSystemTrayIcon::Information,
                     10000);
             } else {


### PR DESCRIPTION
Seeing a message with incorrect English after every connect has bugged me.  "were" refers to somthing in the past, while "are" is correct when we've just entered the connected state.